### PR TITLE
Add ZipRecruiter API connector and multi-source ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Prototype for an intelligent job discovery tool.
 
 ## Architecture
 
-- Modular source connectors for job APIs and compliant scrapers (Adzuna implemented)
+- Modular source connectors for job APIs and compliant scrapers (Adzuna and ZipRecruiter implemented)
 - Parsing layer normalizes data and extracts skills
 - PostgreSQL backend with full-text and vector search (pgvector)
 - Search module provides keyword and semantic queries
@@ -21,10 +21,11 @@ Prototype for an intelligent job discovery tool.
 
 ## Usage
 
-1. Set environment variables for the Adzuna API credentials:
+1. Set environment variables for the API credentials (Adzuna and ZipRecruiter):
    ```bash
    export ADZUNA_APP_ID="your_app_id"
    export ADZUNA_APP_KEY="your_app_key"
+   export ZIPRECRUITER_API_KEY="your_api_key"
    ```
 2. Run the ingestion pipeline:
    ```bash

--- a/job_discovery_project/config.py
+++ b/job_discovery_project/config.py
@@ -10,6 +10,7 @@ class Settings:
     linkedin_password: str = os.getenv("LINKEDIN_PASSWORD", "")
     adzuna_app_id: str = os.getenv("ADZUNA_APP_ID", "")
     adzuna_app_key: str = os.getenv("ADZUNA_APP_KEY", "")
+    ziprecruiter_api_key: str = os.getenv("ZIPRECRUITER_API_KEY", "")
 
 
 settings = Settings()

--- a/job_discovery_project/data_sources/ziprecruiter_client.py
+++ b/job_discovery_project/data_sources/ziprecruiter_client.py
@@ -1,0 +1,40 @@
+from typing import Iterable, Dict, Any
+
+import requests
+
+from .base import JobSource
+from ..config import settings
+
+
+class ZipRecruiterClient(JobSource):
+    """Client for the ZipRecruiter job search API."""
+
+    source_name = "ziprecruiter"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or settings.ziprecruiter_api_key
+
+    def fetch_jobs(
+        self,
+        search: str = "software engineer",
+        location: str = "United States",
+        jobs_per_page: int = 20,
+    ) -> Iterable[Dict[str, Any]]:
+        """Fetch job postings from ZipRecruiter.
+
+        Returns an empty list if API credentials are missing.
+        """
+        if not self.api_key:
+            return []
+
+        url = "https://api.ziprecruiter.com/jobs/v1"
+        params = {
+            "api_key": self.api_key,
+            "search": search,
+            "location": location,
+            "jobs_per_page": jobs_per_page,
+        }
+        resp = requests.get(url, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("jobs", [])

--- a/job_discovery_project/jobs_pipeline.py
+++ b/job_discovery_project/jobs_pipeline.py
@@ -1,6 +1,8 @@
 from typing import List
 
 from .data_sources.adzuna_client import AdzunaClient
+from .data_sources.ziprecruiter_client import ZipRecruiterClient
+from .data_sources.base import JobSource
 from .parsers.normalize import normalize_job
 from .db.models import Job
 from .db.db_client import get_session, init_db
@@ -9,9 +11,13 @@ from .db.db_client import get_session, init_db
 def run_pipeline() -> List[Job]:
     """Run a single ingestion cycle and return normalized jobs."""
     init_db()
-    source = AdzunaClient()
-    raw_jobs = source.fetch_jobs()
-    jobs = [Job(**normalize_job(raw, source.source_name)) for raw in raw_jobs]
+    sources: list[JobSource] = [AdzunaClient(), ZipRecruiterClient()]
+    jobs: list[Job] = []
+    for source in sources:
+        raw_jobs = source.fetch_jobs()
+        jobs.extend(
+            [Job(**normalize_job(raw, source.source_name)) for raw in raw_jobs]
+        )
     with get_session() as session:
         session.add_all(jobs)
         session.commit()

--- a/job_discovery_project/parsers/normalize.py
+++ b/job_discovery_project/parsers/normalize.py
@@ -25,6 +25,19 @@ def normalize_job(raw: Dict[str, Any], source: str) -> Dict[str, Any]:
             "posting_date": _parse_date(raw.get("created")),
         }
 
+    if source == "ziprecruiter":
+        company = raw.get("hiring_company", {})
+        return {
+            "title": raw.get("name", ""),
+            "company": company.get("name", ""),
+            "location": raw.get("location", ""),
+            "description": raw.get("snippet", ""),
+            "skills": [],
+            "source": source,
+            "url": raw.get("url", ""),
+            "posting_date": _parse_date(raw.get("posted_time")),
+        }
+
     return {
         "title": raw.get("title", ""),
         "company": raw.get("company", ""),


### PR DESCRIPTION
## Summary
- add ZipRecruiter API client and hook into ingestion pipeline
- normalize ZipRecruiter payloads alongside existing Adzuna handling
- document new API credential and multi-source setup

## Testing
- `python -m py_compile $(git ls-files "*.py")`


------
https://chatgpt.com/codex/tasks/task_e_6891b77faab0832d98aa9479c60401d2