### PR TITLE
Add USAJobs and JobsPikr connectors with test suite

### DIFF
--- a/config.py
+++ b/config.py
@@ -11,6 +11,9 @@ class Settings:
     adzuna_app_id: str = os.getenv("ADZUNA_APP_ID", "")
     adzuna_app_key: str = os.getenv("ADZUNA_APP_KEY", "")
     ziprecruiter_api_key: str = os.getenv("ZIPRECRUITER_API_KEY", "")
+    usajobs_api_key: str = os.getenv("USAJOBS_API_KEY", "")
+    usajobs_user_agent: str = os.getenv("USAJOBS_USER_AGENT", "")
+    jobspikr_api_key: str = os.getenv("JOBSPIKR_API_KEY", "")
 
 
 settings = Settings()

--- a/data_sources/adzuna_client.py
+++ b/data_sources/adzuna_client.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, Union
 
 import requests
 
@@ -11,7 +11,7 @@ class AdzunaClient(JobSource):
 
     source_name = "adzuna"
 
-    def __init__(self, app_id: str | None = None, app_key: str | None = None) -> None:
+    def __init__(self, app_id: Union[str, None] = None, app_key: Union[str, None] = None) -> None:
         self.app_id = app_id or settings.adzuna_app_id
         self.app_key = app_key or settings.adzuna_app_key
 

--- a/data_sources/indeed_client.py
+++ b/data_sources/indeed_client.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, Union
 
 import requests
 
@@ -11,7 +11,7 @@ class IndeedClient(JobSource):
 
     source_name = "indeed"
 
-    def __init__(self, api_key: str | None = None) -> None:
+    def __init__(self, api_key: Union[str, None] = None) -> None:
         self.api_key = api_key or settings.indeed_api_key
 
     def fetch_jobs(self, query: str = "software engineer", location: str = "United States") -> Iterable[Dict[str, Any]]:

--- a/data_sources/jobspikr_client.py
+++ b/data_sources/jobspikr_client.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, Union
 
 import requests
 
@@ -11,7 +11,7 @@ class JobsPikrClient(JobSource):
 
     source_name = "jobspikr"
 
-    def __init__(self, api_key: str | None = None) -> None:
+    def __init__(self, api_key: Union[str, None] = None) -> None:
         self.api_key = api_key or settings.jobspikr_api_key
 
     def fetch_jobs(

--- a/data_sources/jobspikr_client.py
+++ b/data_sources/jobspikr_client.py
@@ -1,0 +1,40 @@
+from typing import Iterable, Dict, Any
+
+import requests
+
+from .base import JobSource
+from config import settings
+
+
+class JobsPikrClient(JobSource):
+    """Client for the JobsPikr commercial job listings API."""
+
+    source_name = "jobspikr"
+
+    def __init__(self, api_key: str | None = None) -> None:
+        self.api_key = api_key or settings.jobspikr_api_key
+
+    def fetch_jobs(
+        self,
+        query: str = "software engineer",
+        location: str = "United States",
+        results_per_page: int = 20,
+    ) -> Iterable[Dict[str, Any]]:
+        """Fetch job postings from the JobsPikr API.
+
+        Returns an empty list if API credentials are missing.
+        """
+        if not self.api_key:
+            return []
+
+        url = "https://api.jobspikr.com/v2/data"
+        headers = {"x-api-key": self.api_key}
+        params = {
+            "query": query,
+            "country": location,
+            "per_page": results_per_page,
+        }
+        response = requests.get(url, headers=headers, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("data", [])

--- a/data_sources/usajobs_client.py
+++ b/data_sources/usajobs_client.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, Union
 
 import requests
 
@@ -13,8 +13,8 @@ class USAJobsClient(JobSource):
 
     def __init__(
         self,
-        api_key: str | None = None,
-        user_agent: str | None = None,
+        api_key: Union[str, None] = None,
+        user_agent: Union[str, None] = None,
     ) -> None:
         self.api_key = api_key or settings.usajobs_api_key
         self.user_agent = user_agent or settings.usajobs_user_agent

--- a/data_sources/usajobs_client.py
+++ b/data_sources/usajobs_client.py
@@ -1,0 +1,45 @@
+from typing import Iterable, Dict, Any
+
+import requests
+
+from .base import JobSource
+from config import settings
+
+
+class USAJobsClient(JobSource):
+    """Client for the USAJOBS search API."""
+
+    source_name = "usajobs"
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        user_agent: str | None = None,
+    ) -> None:
+        self.api_key = api_key or settings.usajobs_api_key
+        self.user_agent = user_agent or settings.usajobs_user_agent
+
+    def fetch_jobs(
+        self,
+        query: str = "software engineer",
+        location: str = "United States",
+        results_per_page: int = 20,
+    ) -> Iterable[Dict[str, Any]]:
+        """Fetch job postings from the USAJOBS API.
+
+        Returns an empty list if API credentials are missing.
+        """
+        if not self.api_key or not self.user_agent:
+            return []
+
+        url = "https://data.usajobs.gov/api/search"
+        headers = {"Authorization-Key": self.api_key, "User-Agent": self.user_agent}
+        params = {
+            "Keyword": query,
+            "LocationName": location,
+            "ResultsPerPage": results_per_page,
+        }
+        response = requests.get(url, headers=headers, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("SearchResult", {}).get("SearchResultItems", [])

--- a/data_sources/ziprecruiter_client.py
+++ b/data_sources/ziprecruiter_client.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Dict, Any
+from typing import Iterable, Dict, Any, Union
 
 import requests
 
@@ -11,7 +11,7 @@ class ZipRecruiterClient(JobSource):
 
     source_name = "ziprecruiter"
 
-    def __init__(self, api_key: str | None = None) -> None:
+    def __init__(self, api_key: Union[str, None] = None) -> None:
         self.api_key = api_key or settings.ziprecruiter_api_key
 
     def fetch_jobs(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ spacy
 sentence-transformers
 fastapi
 uvicorn
+pytest

--- a/search/vectorizer.py
+++ b/search/vectorizer.py
@@ -1,8 +1,8 @@
-from typing import List
+from typing import List, Union
 
 from sentence_transformers import SentenceTransformer
 
-_model: SentenceTransformer | None = None
+_model: Union[SentenceTransformer, None] = None
 
 
 def get_model() -> SentenceTransformer:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from db import db_client
+from db.models import Base
+
+
+@pytest.fixture(autouse=True)
+def in_memory_db(monkeypatch):
+    engine = create_engine("sqlite:///:memory:", future=True)
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def get_session():
+        return TestingSessionLocal()
+
+    monkeypatch.setattr(db_client, "engine", engine)
+    monkeypatch.setattr(db_client, "SessionLocal", TestingSessionLocal)
+    monkeypatch.setattr(db_client, "get_session", get_session)
+    yield

--- a/tests/test_data_sources.py
+++ b/tests/test_data_sources.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+
+from data_sources.adzuna_client import AdzunaClient
+from data_sources.ziprecruiter_client import ZipRecruiterClient
+from data_sources.usajobs_client import USAJobsClient
+from data_sources.jobspikr_client import JobsPikrClient
+
+
+class DummyResponse(SimpleNamespace):
+    def json(self):
+        return self.data
+
+    def raise_for_status(self):
+        pass
+
+
+def test_adzuna_fetch(monkeypatch):
+    sample = {"results": [{"title": "A"}]}
+
+    def fake_get(url, params=None, timeout=0):
+        return DummyResponse(data=sample)
+
+    monkeypatch.setattr("requests.get", fake_get)
+    client = AdzunaClient(app_id="id", app_key="key")
+    jobs = client.fetch_jobs()
+    assert jobs == sample["results"]
+
+
+def test_ziprecruiter_fetch(monkeypatch):
+    sample = {"jobs": [{"name": "B"}]}
+
+    def fake_get(url, params=None, timeout=0):
+        return DummyResponse(data=sample)
+
+    monkeypatch.setattr("requests.get", fake_get)
+    client = ZipRecruiterClient(api_key="key")
+    jobs = client.fetch_jobs()
+    assert jobs == sample["jobs"]
+
+
+def test_usajobs_fetch(monkeypatch):
+    sample = {"SearchResult": {"SearchResultItems": [{"MatchedObjectId": 1}]}}
+
+    def fake_get(url, headers=None, params=None, timeout=0):
+        return DummyResponse(data=sample)
+
+    monkeypatch.setattr("requests.get", fake_get)
+    client = USAJobsClient(api_key="key", user_agent="agent")
+    jobs = client.fetch_jobs()
+    assert jobs == sample["SearchResult"]["SearchResultItems"]
+
+
+def test_jobspikr_fetch(monkeypatch):
+    sample = {"data": [{"title": "C"}]}
+
+    def fake_get(url, headers=None, params=None, timeout=0):
+        return DummyResponse(data=sample)
+
+    monkeypatch.setattr("requests.get", fake_get)
+    client = JobsPikrClient(api_key="key")
+    jobs = client.fetch_jobs()
+    assert jobs == sample["data"]
+
+
+def test_missing_credentials_return_empty():
+    assert AdzunaClient().fetch_jobs() == []
+    assert ZipRecruiterClient().fetch_jobs() == []
+    assert USAJobsClient().fetch_jobs() == []
+    assert JobsPikrClient().fetch_jobs() == []

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,11 @@
+from db.db_client import get_session, init_db
+from db.models import Job
+
+
+def test_init_and_crud():
+    init_db()
+    with get_session() as session:
+        job = Job(title="T", company="C", location="L")
+        session.add(job)
+        session.commit()
+        assert session.query(Job).count() == 1

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,51 @@
+from parsers.normalize import normalize_job
+
+
+def test_normalize_adzuna():
+    raw = {
+        "title": "Software Engineer",
+        "company": {"display_name": "ABC"},
+        "location": {"display_name": "NY"},
+        "description": "desc",
+        "redirect_url": "url",
+        "created": "2024-01-01T00:00:00Z",
+    }
+    job = normalize_job(raw, "adzuna")
+    assert job["title"] == "Software Engineer"
+    assert job["company"] == "ABC"
+    assert job["location"] == "NY"
+    assert job["url"] == "url"
+    assert job["posting_date"].isoformat() == "2024-01-01"
+
+
+def test_normalize_ziprecruiter():
+    raw = {
+        "name": "Dev",
+        "hiring_company": {"name": "XYZ"},
+        "location": "SF",
+        "snippet": "desc",
+        "url": "u",
+        "posted_time": "2024-02-02T00:00:00Z",
+    }
+    job = normalize_job(raw, "ziprecruiter")
+    assert job["title"] == "Dev"
+    assert job["company"] == "XYZ"
+    assert job["location"] == "SF"
+    assert job["url"] == "u"
+    assert job["posting_date"].isoformat() == "2024-02-02"
+
+
+def test_normalize_generic():
+    raw = {
+        "title": "Analyst",
+        "company": "ACME",
+        "location": "LA",
+        "description": "desc",
+        "url": "link",
+        "posting_date": None,
+    }
+    job = normalize_job(raw, "other")
+    assert job["title"] == "Analyst"
+    assert job["company"] == "ACME"
+    assert job["location"] == "LA"
+    assert job["url"] == "link"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,26 @@
+from db.db_client import get_session
+from db.models import Job
+from search.search_index import search_jobs
+from search.recommend import recommend_jobs
+
+
+def setup_jobs():
+    with get_session() as session:
+        job1 = Job(title="Python Dev", company="A", description="Python role", skills=["python"])
+        job2 = Job(title="Java Dev", company="B", description="Java role", skills=["java"])
+        session.add_all([job1, job2])
+        session.commit()
+
+
+def test_search_jobs():
+    setup_jobs()
+    results = search_jobs("Python")
+    assert len(results) == 1
+    assert results[0].title == "Python Dev"
+
+
+def test_recommend_jobs():
+    setup_jobs()
+    results = recommend_jobs(["java"])
+    assert len(results) == 1
+    assert results[0].company == "B"


### PR DESCRIPTION
## Summary
- add USAJobs and JobsPikr data source connectors
- configure new API keys
- introduce pytest-based tests for connectors, normalization, DB CRUD, search, and recommendations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689275306c60832d87543f1ad0f065b1